### PR TITLE
Doesn't build on GHC < 7.10

### DIFF
--- a/tubes.cabal
+++ b/tubes.cabal
@@ -78,7 +78,7 @@ library
                        FlexibleInstances, FlexibleContexts, DeriveFunctor
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && < 5,
+  build-depends:       base >=4.8 && < 5,
                        transformers >=0.3,
                        free >=4.12,
                        mtl,


### PR DESCRIPTION
GHC 7.8 build error:

```
Tubes/Core.hs:224:8:
    Couldn't match type ‘FreeT (TubeF a0 b) m r0’
                  with ‘forall x1. Tube x1 b m ()’
    Expected type: Source b m ()
                   -> Sink (Maybe b) m s -> Tube (Maybe b) x m s
      Actual type: Tube a0 b m r0
                   -> Tube (Maybe b) x m s -> Tube (Maybe b) x m s
    Relevant bindings include
      (|>) :: Source b m () -> Sink (Maybe b) m s -> Sink (Maybe b) m s
        (bound at Tubes/Core.hs:224:1)
    In the expression: (\|>)
    In an equation for ‘|>’: (|>) = (\|>)
```

I've revised existing versions (https://hackage.haskell.org/package/tubes-0.2.2.0/revisions/), a new release is only needed if you wish to restore backwards compatibility
